### PR TITLE
Brand accound login bug

### DIFF
--- a/src/utils/findElementByTrackingParams.ts
+++ b/src/utils/findElementByTrackingParams.ts
@@ -8,22 +8,27 @@ export function findElementByTrackingParams<T = Element>(
   elementSelector: string
 ): T | null {
   let returnElement = null;
+  let errorAlerted = false;
   const elems = document.querySelectorAll<any>(elementSelector);
-  for (let i = 0; i < elems.length; i++) {
-    if (elems[i] !== undefined) {
-      if (
-        elems[i].trackedParams === undefined &&
-        elems[i].controllerProxy.trackedParams === undefined
-      ) {
-        debugErr("TrackdParams property is not found");
-      }
 
-      if (
-        elems[i].trackedParams === trackingParams ||
-        elems[i].controllerProxy.trackedParams === trackingParams
-      ) {
-        returnElement = elems[i];
-        break;
+  for (let i = 0; i < elems.length; i++) {
+    if (
+      elems[i]?.trackedParams === undefined &&
+      elems[i]?.controllerProxy?.trackedParams === undefined
+    ) {
+      debugErr("TrackdParams property is not found");
+    }
+
+    if (elems[i].trackedParams === trackingParams) {
+      returnElement = elems[i];
+      break;
+    } else if (elems[i]?.controllerProxy?.trackedParams === trackingParams) {
+      returnElement = elems[i];
+      break;
+    } else {
+      if (!errorAlerted) {
+        void searchTrackedParamsByObject(trackingParams, elems[i]);
+        errorAlerted = true;
       }
     }
   }
@@ -104,6 +109,30 @@ export async function reSearchElementAllByCommentId<T = ShadyElement>(
 
     search();
   });
+}
+
+export async function searchTrackedParamsByObject(
+  param: string,
+  elem: Element
+): Promise<any> {
+  const elemObj = Object(elem);
+
+  const search = (obj: Record<string, any>, history: string[]): void => {
+    Object.keys(obj).forEach((k) => {
+      if (typeof obj[k] === "object") {
+        search(obj[k], [...history, k]);
+      } else if (obj[k] === param) {
+        history.push(k);
+        alert(
+          `[Return YouTube Comment Username] Unknown Object format!\n"${history.join(
+            ">"
+          )}"`
+        );
+      }
+    });
+  };
+
+  search(elemObj, []);
 }
 
 /**

--- a/src/utils/findElementByTrackingParams.ts
+++ b/src/utils/findElementByTrackingParams.ts
@@ -1,3 +1,5 @@
+import { debugErr } from "./debugLog";
+
 /**
  * trackingParams(コンポーネント固有のID?)から要素を検索
  */
@@ -8,12 +10,21 @@ export function findElementByTrackingParams<T = Element>(
   let returnElement = null;
   const elems = document.querySelectorAll<any>(elementSelector);
   for (let i = 0; i < elems.length; i++) {
-    if (
-      elems[i].trackedParams === trackingParams ||
-      elems[i].controllerProxy.trackedParams === trackingParams
-    ) {
-      returnElement = elems[i];
-      break;
+    if (elems[i] !== undefined) {
+      if (
+        elems[i].trackedParams === undefined &&
+        elems[i].controllerProxy.trackedParams === undefined
+      ) {
+        debugErr("TrackdParams property is not found");
+      }
+
+      if (
+        elems[i].trackedParams === trackingParams ||
+        elems[i].controllerProxy.trackedParams === trackingParams
+      ) {
+        returnElement = elems[i];
+        break;
+      }
     }
   }
 
@@ -57,6 +68,10 @@ export function findElementAllByCommentId<T = Element>(
   const returnElements: T[] = [];
   const elems = document.querySelectorAll<any>(elementSelector);
   elems.forEach((elem) => {
+    if (elem !== undefined && elem.__data.data.commentId === undefined) {
+      debugErr("Reply CommentId is not found");
+    }
+
     if (elem.__data.data.commentId === commnetId) {
       returnElements.push(elem);
     }

--- a/src/utils/findElementByTrackingParams.ts
+++ b/src/utils/findElementByTrackingParams.ts
@@ -7,9 +7,11 @@ export function findElementByTrackingParams<T = Element>(
 ): T | null {
   let returnElement = null;
   const elems = document.querySelectorAll<any>(elementSelector);
-
   for (let i = 0; i < elems.length; i++) {
-    if (elems[i].trackedParams === trackingParams) {
+    if (
+      elems[i].trackedParams === trackingParams ||
+      elems[i].controllerProxy.trackedParams === trackingParams
+    ) {
       returnElement = elems[i];
       break;
     }


### PR DESCRIPTION
In some environments (e.g., when logging in to a brand account)
Fixed bug where tracedparams could not be found due to different format of ytd-comment-thread-renderer element properties

#61 
https://greasyfork.org/ja/scripts/460361-return-youtube-comment-username/discussions/195466