### PR TITLE
Performance up and bug fix

### DIFF
--- a/src/handlers/handleYtAppendContinuationItemsAction.ts
+++ b/src/handlers/handleYtAppendContinuationItemsAction.ts
@@ -27,7 +27,7 @@ export function handleYtAppendContinuationItemsAction(
       rewriteReplytNameFromContinuationItems(
         replyDetail.args[0].appendContinuationItemsAction.continuationItems
       );
-    }, 1);
+    }, 100);
   } else {
     // comment
     const commentDetail: YtAction<
@@ -39,6 +39,6 @@ export function handleYtAppendContinuationItemsAction(
       rewriteCommentNameFromContinuationItems(
         commentDetail.args[0].appendContinuationItemsAction.continuationItems
       );
-    }, 10);
+    }, 400);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,7 @@ export default function main(): void {
   debugLog("Script start");
 
   const handleYtAction = (e: CustomEvent<YtAction<any, any>>): void => {
-    const { actionName } = e.detail;
-    switch (actionName) {
+    switch (e.detail.actionName) {
       case "yt-append-continuation-items-action":
         handleYtAppendContinuationItemsAction(e.detail);
         break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,6 @@ export default function main(): void {
    * page change
    */
   document.addEventListener("yt-navigate-finish", ({ detail }) => {
-    document.removeEventListener("yt-action", handleYtAction);
-    document.addEventListener("yt-action", handleYtAction);
     document.dispatchEvent(new Event("rycu-pagechange"));
   });
 }

--- a/src/rewrites/comment.ts
+++ b/src/rewrites/comment.ts
@@ -10,6 +10,7 @@ import {
 import { nameRewriteOfCommentRenderer } from "./rewriteOfCommentRenderer/nameRewriteOfCommentRenderer";
 import { debugErr, debugLog } from "src/utils/debugLog";
 import { rewriteTeaserReplytNameFromContinuationItems } from "./reply";
+import { getShadyChildren } from "src/utils/getShadyChildren";
 
 /**
  * confinuationItemsを元にコメントの名前を書き換える。
@@ -48,8 +49,7 @@ function reWriteCommentElem(
   commentElem: ShadyElement,
   commentThreadRenderer: ConfinuationItem
 ): void {
-  const commentRenderer =
-    commentElem.__shady_native_children.namedItem("comment");
+  const commentRenderer = getShadyChildren(commentElem, 1, "comment");
 
   if (commentRenderer !== null && commentRenderer !== undefined) {
     let isContainer =

--- a/src/rewrites/comment.ts
+++ b/src/rewrites/comment.ts
@@ -19,26 +19,26 @@ export function rewriteCommentNameFromContinuationItems(
 ): void {
   debugLog("Comment Rewrite");
 
-  continuationItems.forEach((continuationItem) => {
-    const { commentThreadRenderer } = continuationItem;
-
-    if (commentThreadRenderer !== undefined) {
-      const { trackingParams } = commentThreadRenderer;
-      void getCommentElem(trackingParams).then((commentElem) => {
-        reWriteCommentElem(commentElem, commentThreadRenderer);
+  for (let i = 0; i < continuationItems.length; i++) {
+    if (continuationItems[i].commentThreadRenderer !== undefined) {
+      void getCommentElem(
+        continuationItems[i].commentThreadRenderer.trackingParams
+      ).then((commentElem) => {
+        reWriteCommentElem(
+          commentElem,
+          continuationItems[i].commentThreadRenderer
+        );
       });
 
-      if (
-        commentThreadRenderer.replies?.commentRepliesRenderer.teaserContents !==
-        undefined
-      ) {
+      const teaserContents =
+        continuationItems[i].commentThreadRenderer.replies
+          ?.commentRepliesRenderer.teaserContents;
+      if (teaserContents !== undefined) {
         // teaser repliy exist
-        rewriteTeaserReplytNameFromContinuationItems(
-          commentThreadRenderer.replies?.commentRepliesRenderer.teaserContents
-        );
+        rewriteTeaserReplytNameFromContinuationItems(teaserContents);
       }
     }
-  });
+  }
 }
 
 /**
@@ -48,11 +48,8 @@ function reWriteCommentElem(
   commentElem: ShadyElement,
   commentThreadRenderer: ConfinuationItem
 ): void {
-  const commentRenderer = Array.from(
-    commentElem.__shady_native_children
-  ).filter((elem) => {
-    return elem.id === "comment";
-  })[0];
+  const commentRenderer =
+    commentElem.__shady_native_children.namedItem("comment");
 
   if (commentRenderer !== null && commentRenderer !== undefined) {
     let isContainer =

--- a/src/rewrites/reply.ts
+++ b/src/rewrites/reply.ts
@@ -24,15 +24,15 @@ export function rewriteReplytNameFromContinuationItems(
 ): void {
   debugLog("Reply Rewrite");
 
-  continuationItems.forEach((continuationItem) => {
-    const { commentRenderer } = continuationItem;
+  for (let i = 0; i < continuationItems.length; i++) {
+    const { commentRenderer } = continuationItems[i];
 
     if (commentRenderer !== undefined) {
       void getReplyElem(commentRenderer.trackingParams).then((replyElem) => {
         reWriteReplyElem(replyElem, commentRenderer);
       });
     }
-  });
+  }
 }
 
 /**
@@ -89,8 +89,8 @@ export function rewriteTeaserReplytNameFromContinuationItems(
 ): void {
   debugLog("Teaser Reply Rewrite");
 
-  continuationItems.forEach((continuationItem) => {
-    const { commentRenderer } = continuationItem;
+  for (let i = 0; i < continuationItems.length; i++) {
+    const { commentRenderer } = continuationItems[i];
 
     if (commentRenderer !== undefined) {
       void reSearchElementAllByCommentId(
@@ -111,7 +111,7 @@ export function rewriteTeaserReplytNameFromContinuationItems(
         });
       });
     }
-  });
+  }
 }
 
 /**

--- a/src/rewrites/rewriteOfCommentRenderer/mentionRewriteOfCommentRenderer.ts
+++ b/src/rewrites/rewriteOfCommentRenderer/mentionRewriteOfCommentRenderer.ts
@@ -1,6 +1,7 @@
 import { type ShadyElement } from "../../utils/findElementByTrackingParams";
 import { getUserName } from "../../utils/getUserName";
 import { debugErr } from "src/utils/debugLog";
+import { getShadyChildren } from "src/utils/getShadyChildren";
 
 /**
  * comment内のaタクを全取得して
@@ -9,10 +10,9 @@ import { debugErr } from "src/utils/debugLog";
 export function mentionRewriteOfCommentRenderer(
   commentRenderer: ShadyElement
 ): void {
-  const commentRendererBody =
-    commentRenderer.__shady_native_children.namedItem("body");
+  const commentRendererBody = getShadyChildren(commentRenderer, 3, "body");
 
-  const main = commentRendererBody?.__shady_native_children.namedItem("main");
+  const main = commentRendererBody?.querySelector<ShadyElement>("#main");
 
   if (main !== undefined && main !== null) {
     const aTags = main.querySelectorAll(

--- a/src/rewrites/rewriteOfCommentRenderer/mentionRewriteOfCommentRenderer.ts
+++ b/src/rewrites/rewriteOfCommentRenderer/mentionRewriteOfCommentRenderer.ts
@@ -9,37 +9,32 @@ import { debugErr } from "src/utils/debugLog";
 export function mentionRewriteOfCommentRenderer(
   commentRenderer: ShadyElement
 ): void {
-  const commentRendererBody = Array.from(
-    commentRenderer.__shady_native_children
-  ).filter((elem) => {
-    return elem.id === "body";
-  })[0];
+  const commentRendererBody =
+    commentRenderer.__shady_native_children.namedItem("body");
 
-  const main = Array.from(commentRendererBody.__shady_native_children).filter(
-    (elem) => {
-      return elem.id === "main";
-    }
-  )[0];
+  const main = commentRendererBody?.__shady_native_children.namedItem("main");
 
-  const aTags = main.querySelectorAll(
-    "#comment-content > ytd-expander > #content > #content-text > a"
-  );
+  if (main !== undefined && main !== null) {
+    const aTags = main.querySelectorAll(
+      "#comment-content > ytd-expander > #content > #content-text > a"
+    );
 
-  aTags.forEach((aTag) => {
-    if (aTag.textContent?.match("@.*") !== null) {
-      const href = aTag.getAttribute("href");
+    for (let i = 0; i < aTags.length; i++) {
+      if (aTags[i].textContent?.match("@.*") !== null) {
+        const href = aTags[i].getAttribute("href");
 
-      if (href !== null) {
-        void getUserName(href.split("/")[2])
-          .then((name) => {
-            aTag.textContent = `@${name} `;
-          })
-          .catch((e) => {
-            debugErr(e);
-          });
-      } else {
-        debugErr("Mention Atag is have not Href attr");
+        if (href !== null) {
+          void getUserName(href.split("/")[2])
+            .then((name) => {
+              aTags[i].textContent = `@${name} `;
+            })
+            .catch((e) => {
+              debugErr(e);
+            });
+        } else {
+          debugErr("Mention Atag is have not Href attr");
+        }
       }
     }
-  });
+  }
 }

--- a/src/rewrites/rewriteOfCommentRenderer/nameRewriteOfCommentRenderer.ts
+++ b/src/rewrites/rewriteOfCommentRenderer/nameRewriteOfCommentRenderer.ts
@@ -1,4 +1,5 @@
 import { debugErr } from "src/utils/debugLog";
+import { getShadyChildren } from "src/utils/getShadyChildren";
 import { escapeString } from "../../utils/escapeString";
 import { type ShadyElement } from "../../utils/findElementByTrackingParams";
 import { getUserName } from "../../utils/getUserName";
@@ -14,8 +15,11 @@ export function nameRewriteOfCommentRenderer(
   isNameContainerRender: boolean,
   userId: string
 ): void {
-  const commentRendererBody =
-    commentRenderer.__shady_native_children.namedItem("body");
+  const commentRendererBody: ShadyElement | null = getShadyChildren(
+    commentRenderer,
+    3,
+    "body"
+  );
 
   if (commentRendererBody === null) {
     throw new Error("[rycu] comment renderer body is null");
@@ -29,8 +33,7 @@ export function nameRewriteOfCommentRenderer(
    * チャンネル所有者のコメントは別の要素に名前がかかれる
    */
   if (isNameContainerRender) {
-    const containerMain =
-      commentRendererBody.__shady_native_children.namedItem("main");
+    const containerMain = getShadyChildren(commentRendererBody, 1, "main");
 
     if (containerMain !== null) {
       nameElem = containerMain.querySelector<ShadyElement>(

--- a/src/rewrites/rewriteOfCommentRenderer/nameRewriteOfCommentRenderer.ts
+++ b/src/rewrites/rewriteOfCommentRenderer/nameRewriteOfCommentRenderer.ts
@@ -14,11 +14,12 @@ export function nameRewriteOfCommentRenderer(
   isNameContainerRender: boolean,
   userId: string
 ): void {
-  const commentRendererBody = Array.from(
-    commentRenderer.__shady_native_children
-  ).filter((elem) => {
-    return elem.id === "body";
-  })[0];
+  const commentRendererBody =
+    commentRenderer.__shady_native_children.namedItem("body");
+
+  if (commentRendererBody === null) {
+    throw new Error("[rycu] comment renderer body is null");
+  }
 
   let nameElem = commentRendererBody.querySelector<ShadyElement>(
     "#main > #header > #header-author > h3 > a > span"
@@ -28,13 +29,14 @@ export function nameRewriteOfCommentRenderer(
    * チャンネル所有者のコメントは別の要素に名前がかかれる
    */
   if (isNameContainerRender) {
-    nameElem = Array.from(commentRendererBody.__shady_native_children)
-      .filter((elem) => {
-        return elem.id === "main";
-      })[0]
-      .querySelector<ShadyElement>(
+    const containerMain =
+      commentRendererBody.__shady_native_children.namedItem("main");
+
+    if (containerMain !== null) {
+      nameElem = containerMain.querySelector<ShadyElement>(
         "#header > #header-author > #author-comment-badge > ytd-author-comment-badge-renderer > a > #channel-name > #container > #text-container > yt-formatted-string"
       );
+    }
   }
 
   /**

--- a/src/utils/escapeString.ts
+++ b/src/utils/escapeString.ts
@@ -1,15 +1,15 @@
 export function escapeString(text: string): string {
   return text
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll(`"`, `&quot;`)
-    .replaceAll(`'`, `&#39;`);
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, `&quot;`)
+    .replace(/'/g, `&#39;`);
 }
 
 export function decodeString(text: string): string {
   return text
-    .replaceAll("&lt;", "<")
-    .replaceAll("&gt;", ">")
-    .replaceAll(`&quot;`, `"`)
-    .replaceAll(`&#39;`, `'`);
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, `"`)
+    .replace(/&#39;/g, `'`);
 }

--- a/src/utils/escapeString.ts
+++ b/src/utils/escapeString.ts
@@ -3,7 +3,8 @@ export function escapeString(text: string): string {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, `&quot;`)
-    .replace(/'/g, `&#39;`);
+    .replace(/'/g, `&#39;`)
+    .replace(/&/g, `&amp;`);
 }
 
 export function decodeString(text: string): string {
@@ -11,5 +12,6 @@ export function decodeString(text: string): string {
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, `"`)
-    .replace(/&#39;/g, `'`);
+    .replace(/&#39;/g, `'`)
+    .replace(/&amp;/g, `&`);
 }

--- a/src/utils/findElementByTrackingParams.ts
+++ b/src/utils/findElementByTrackingParams.ts
@@ -123,6 +123,9 @@ export async function reSearchElementAllByCommentId<T = ShadyElement>(
   });
 }
 
+/**
+ * エラーが出た時にtrackedparamsまでのpathをユーザーに通知
+ */
 export async function searchTrackedParamsByObject(
   param: string,
   elem: Element

--- a/src/utils/findElementByTrackingParams.ts
+++ b/src/utils/findElementByTrackingParams.ts
@@ -72,27 +72,27 @@ export function findElementAllByCommentId<T = Element>(
 ): T[] {
   const returnElements: T[] = [];
   const elems = document.querySelectorAll<any>(elementSelector);
-  elems.forEach((elem) => {
-    if (elem !== undefined) {
+  for (let i = 0; i < elems.length; i++) {
+    if (elems[i] !== undefined) {
       if (
-        elem?.__data?.data?.commentId === undefined &&
-        elem?.controllerProxy?.__data?.data?.commentId === undefined
+        elems[i]?.__data?.data?.commentId === undefined &&
+        elems[i]?.controllerProxy?.__data?.data?.commentId === undefined
       ) {
         debugErr("Reply CommentId is not found");
-        console.log(elem);
+        console.log(elems[i]);
       } else if (
-        elem?.__data?.data?.commentId !== undefined &&
-        elem.__data.data.commentId === commnetId
+        elems[i]?.__data?.data?.commentId !== undefined &&
+        elems[i].__data.data.commentId === commnetId
       ) {
-        returnElements.push(elem);
+        returnElements.push(elems[i]);
       } else if (
-        elem?.controllerProxy?.__data?.data?.commentId !== undefined &&
-        elem.controllerProxy.__data.data.commentId === commnetId
+        elems[i]?.controllerProxy?.__data?.data?.commentId !== undefined &&
+        elems[i].controllerProxy.__data.data.commentId === commnetId
       ) {
-        returnElements.push(elem);
+        returnElements.push(elems[i]);
       }
     }
-  });
+  }
   return returnElements;
 }
 
@@ -151,7 +151,7 @@ export async function searchTrackedParamsByObject(
  * polymerの要素？知らんけど
  */
 export interface ShadyElement extends HTMLElement {
-  __shady_native_children: ShadyElement[];
+  __shady_native_children: HTMLCollectionOf<ShadyElement>;
   __shady_native_innerHTML: string;
   __data: {
     data: {

--- a/src/utils/getShadyChildren.ts
+++ b/src/utils/getShadyChildren.ts
@@ -1,0 +1,28 @@
+import { type ShadyElement } from "./findElementByTrackingParams";
+
+export function getShadyChildren(
+  parentElement: ShadyElement,
+  index: number,
+  id: string
+): ShadyElement | null {
+  let returnElem: ShadyElement | null;
+
+  const child = parentElement.__shady_native_children[index];
+  if (child === null || child.id !== id) {
+    returnElem = parentElement.querySelector<ShadyElement>(`#${id}`);
+    console.log(
+      `%cReturn YouTube Comment Username Warning%c %cChildren Cannot Get by Index!%c\n%cid of element attempting to retrieve: ${id}\nIf you find this debug log, please report it to the github issue%c`,
+      "background:#f0e68c; color:#000;font-size:20px;",
+      "",
+      "color:#00c72e;font-size:16px;",
+      "",
+      "color: #13ebdc;",
+      "",
+      "\nhttps://github.com/yakisova41/return-youtube-comment-username/issues/new?assignees=&labels=bug&projects=&template=bug_report.yaml&title=%5BBug%5D%3A+Children%20Cannot%20Get%20by%20Index"
+    );
+  } else {
+    returnElem = child;
+  }
+
+  return returnElem;
+}

--- a/src/utils/getShadyChildren.ts
+++ b/src/utils/getShadyChildren.ts
@@ -1,5 +1,10 @@
 import { type ShadyElement } from "./findElementByTrackingParams";
 
+/**
+ * 基本的には子要素をindexで取得して負荷を軽減します。
+ * 子要素のidが事前に指定されたidと一致しない場合(仕様変更などで要素の順番が変わった時)に
+ * queryselectorで要素を取得してユーザーにエラーメッセージを出し、issueを促します。
+ */
 export function getShadyChildren(
   parentElement: ShadyElement,
   index: number,

--- a/src/utils/getUserName.ts
+++ b/src/utils/getUserName.ts
@@ -9,7 +9,7 @@ export async function getUserName(id: string): Promise<string> {
     {
       method: "GET",
       cache: "default",
-      keepalive: false,
+      keepalive: true,
     }
   )
     .then(async (res) => {

--- a/src/utils/isCommentRenderer.ts
+++ b/src/utils/isCommentRenderer.ts
@@ -12,11 +12,11 @@ export function isCommentRenderer(
   continuationItems: ContinuationItems | ReplyContinuationItems
 ): boolean {
   if (continuationItems.length > 0) {
-    if (continuationItems[0].hasOwnProperty("commentThreadRenderer")) {
+    if ("commentThreadRenderer" in continuationItems[0]) {
       return false;
     }
 
-    if (continuationItems[0].hasOwnProperty("commentRenderer")) {
+    if ("commentRenderer" in continuationItems[0]) {
       return true;
     }
   }


### PR DESCRIPTION
- setIntervalを10msから400msにすることで、コメントのレンダリングと名前の書き換え処理を同時並列で実行することを(ある程度)防ぎパフォーマンスを向上させます。
- commentRenderer以下の要素(bodyやmain)を取得する際に、filterやqueryselectorを使用するとパフォーマンスが低下するため0.3.11以前に使用されていたchildrenのindexで要素を指定する方法に戻しました。なおyoutubeの仕様変更によりbody, mainのindexが変わって見つからない場合は、queryselectorを使用し応急的に要素を取得します。
- &amp;のエスケープをデコードしていなかった問題を修正 #70 
- foreachをforに変更