### PR TITLE
🐛 Fix: Support for continuationItemsV2

### DIFF
--- a/src/handlers/handleYtAppendContinuationItemsAction.ts
+++ b/src/handlers/handleYtAppendContinuationItemsAction.ts
@@ -1,4 +1,7 @@
-import { isCommentRenderer } from "src/utils/isCommentRenderer";
+import {
+  isCommentRenderer,
+  isCommentRendererV2,
+} from "src/utils/isCommentRenderer";
 import { rewriteCommentNameFromContinuationItems } from "src/rewrites/comment";
 import { rewriteReplytNameFromContinuationItems } from "src/rewrites/reply";
 import {
@@ -12,11 +15,16 @@ import {
  * リプライの読み込み時のaction
  */
 export function handleYtAppendContinuationItemsAction(
-  detail: YtAction<any, any>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  detail: YtAction<any, any>,
 ): void {
   const continuationItems =
     detail.args[0].appendContinuationItemsAction.continuationItems;
-  if (isCommentRenderer(continuationItems)) {
+
+  if (
+    isCommentRenderer(continuationItems) ||
+    isCommentRendererV2(continuationItems)
+  ) {
     // Reply
     const replyDetail: YtAction<
       YtAppendContinuationItemsActionArg0<"reply">,
@@ -25,7 +33,7 @@ export function handleYtAppendContinuationItemsAction(
 
     setTimeout(() => {
       rewriteReplytNameFromContinuationItems(
-        replyDetail.args[0].appendContinuationItemsAction.continuationItems
+        replyDetail.args[0].appendContinuationItemsAction.continuationItems,
       );
     }, 100);
   } else {
@@ -37,7 +45,7 @@ export function handleYtAppendContinuationItemsAction(
 
     setTimeout(() => {
       rewriteCommentNameFromContinuationItems(
-        commentDetail.args[0].appendContinuationItemsAction.continuationItems
+        commentDetail.args[0].appendContinuationItemsAction.continuationItems,
       );
     }, 400);
   }

--- a/src/handlers/handleYtReloadContinuationItemsCommand.ts
+++ b/src/handlers/handleYtReloadContinuationItemsCommand.ts
@@ -9,7 +9,8 @@ import {
  * 最初の20個以内のコメント読み込み時と、新しい順と評価順を切り替えた際のaction
  */
 export function handleYtReloadContinuationItemsCommand(
-  detail: YtAction<any, any>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  detail: YtAction<any, any>,
 ): void {
   const reloadDetail: YtAction<YtReloadContinuationItemsCommandArg0, Element> =
     detail;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { type YtNavigateFinishEvent } from "./types/YtNavigateFinishEvent";
 import { debugLog } from "./utils/debugLog";
 
 export default function main(): void {
-  debugLog("Script start")
+  debugLog("Script start");
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleYtAction = (e: CustomEvent<YtAction<any, any>>): void => {

--- a/src/rewrites/comment.ts
+++ b/src/rewrites/comment.ts
@@ -6,11 +6,15 @@ import {
 import {
   type ContinuationItems,
   type ConfinuationItem,
+  ConfinuationItemV2,
+  isConfinuationItemV1,
+  isConfinuationItemV2,
 } from "src/types/AppendContinuationItemsAction";
 import { nameRewriteOfCommentRenderer } from "./rewriteOfCommentRenderer/nameRewriteOfCommentRenderer";
 import { debugErr, debugLog } from "src/utils/debugLog";
 import { rewriteTeaserReplytNameFromContinuationItems } from "./reply";
 import { getShadyChildren } from "src/utils/getShadyChildren";
+import { nameRewriteOfCommentViewModel } from "./rewriteOfCommentRenderer/nameRewriteOfCommentViewModel";
 
 /**
  * confinuationItemsを元にコメントの名前を書き換える。
@@ -47,25 +51,38 @@ export function rewriteCommentNameFromContinuationItems(
  */
 function reWriteCommentElem(
   commentElem: ShadyElement,
-  commentThreadRenderer: ConfinuationItem,
+  commentThreadRenderer: ConfinuationItem | ConfinuationItemV2,
 ): void {
-  const commentRenderer = getShadyChildren(commentElem, 0, "comment");
+  const commentRenderer = getShadyChildren(commentElem, 1, "comment");
+
   if (commentRenderer !== null && commentRenderer !== undefined) {
-    let isContainer =
-      commentThreadRenderer.comment.commentRenderer.authorIsChannelOwner;
-    if (
-      commentThreadRenderer.comment.commentRenderer.authorCommentBadge !==
-      undefined
-    ) {
-      isContainer = true;
+    if (isConfinuationItemV1(commentThreadRenderer)) {
+      debugLog("Comment continuationItems V1");
+
+      let isContainer =
+        commentThreadRenderer.comment.commentRenderer.authorIsChannelOwner;
+
+      if (
+        commentThreadRenderer.comment.commentRenderer.authorCommentBadge !==
+        undefined
+      ) {
+        isContainer = true;
+      }
+
+      nameRewriteOfCommentRenderer(
+        commentRenderer,
+        isContainer,
+        commentThreadRenderer.comment.commentRenderer.authorEndpoint
+          .browseEndpoint.browseId,
+      );
     }
 
-    nameRewriteOfCommentRenderer(
-      commentRenderer,
-      isContainer,
-      commentThreadRenderer.comment.commentRenderer.authorEndpoint
-        .browseEndpoint.browseId,
-    );
+    if (isConfinuationItemV2(commentThreadRenderer)) {
+      debugLog("Comment continuationItems V2");
+
+      // let isContainer = commentThreadRenderer.commentViewModel.commentViewModel;
+      nameRewriteOfCommentViewModel(commentRenderer);
+    }
   }
 }
 

--- a/src/rewrites/reply.ts
+++ b/src/rewrites/reply.ts
@@ -8,11 +8,15 @@ import {
 import {
   type CommentRenderer,
   type ReplyContinuationItems,
+  ReplyContinuationItemsV2,
+  isReplyContinuationItemsV1,
+  isReplyContinuationItemsV2,
 } from "src/types/AppendContinuationItemsAction";
 import { mentionRewriteOfCommentRenderer } from "./rewriteOfCommentRenderer/mentionRewriteOfCommentRenderer";
 import { nameRewriteOfCommentRenderer } from "./rewriteOfCommentRenderer/nameRewriteOfCommentRenderer";
 import { debugLog } from "src/utils/debugLog";
 import { getUserName } from "src/utils/getUserName";
+import { nameRewriteOfCommentViewModel } from "./rewriteOfCommentRenderer/nameRewriteOfCommentViewModel";
 
 /**
  * confinuationItems(コメントをレンダリングする際の元データ？)のリストを元に
@@ -20,17 +24,41 @@ import { getUserName } from "src/utils/getUserName";
  * Replyの名前を書き換える。
  */
 export function rewriteReplytNameFromContinuationItems(
-  continuationItems: ReplyContinuationItems
+  continuationItems: ReplyContinuationItems | ReplyContinuationItemsV2,
 ): void {
   debugLog("Reply Rewrite");
 
-  for (let i = 0; i < continuationItems.length; i++) {
-    const { commentRenderer } = continuationItems[i];
+  if (isReplyContinuationItemsV1(continuationItems)) {
+    debugLog("Reply continuationItems V1");
 
-    if (commentRenderer !== undefined) {
-      void getReplyElem(commentRenderer.trackingParams).then((replyElem) => {
-        reWriteReplyElem(replyElem, commentRenderer);
-      });
+    for (let i = 0; i < continuationItems.length; i++) {
+      const { commentRenderer } = continuationItems[i];
+
+      if (commentRenderer !== undefined) {
+        void getReplyElem(commentRenderer.trackingParams, "V1").then(
+          (replyElem) => {
+            reWriteReplyElem(replyElem, commentRenderer);
+          },
+        );
+      }
+    }
+  }
+
+  if (isReplyContinuationItemsV2(continuationItems)) {
+    debugLog("Reply continuationItems V2");
+
+    for (let i = 0; i < continuationItems.length; i++) {
+      const { commentViewModel } = continuationItems[i];
+
+      if (commentViewModel !== undefined) {
+        void getReplyElem(
+          commentViewModel.rendererContext.loggingContext.loggingDirectives
+            .trackingParams,
+          "V2",
+        ).then((replyElem) => {
+          reWriteReplyElemV2(replyElem);
+        });
+      }
     }
   }
 }
@@ -40,7 +68,7 @@ export function rewriteReplytNameFromContinuationItems(
  */
 function reWriteReplyElem(
   replyElem: ShadyElement,
-  rendererData: CommentRenderer
+  rendererData: CommentRenderer,
 ): void {
   let isContainer = rendererData.authorIsChannelOwner;
   if (rendererData.authorCommentBadge !== undefined) {
@@ -50,24 +78,32 @@ function reWriteReplyElem(
   nameRewriteOfCommentRenderer(
     replyElem,
     isContainer,
-    rendererData.authorEndpoint.browseEndpoint.browseId
+    rendererData.authorEndpoint.browseEndpoint.browseId,
   );
 
   mentionRewriteOfCommentRenderer(replyElem);
   replyInputRewrite(replyElem);
 }
 
+function reWriteReplyElemV2(replyElem: ShadyElement) {
+  nameRewriteOfCommentViewModel(replyElem);
+}
+
 /**
  * リプライの要素をtrackingParamsから取得
  */
-async function getReplyElem(trackedParams: string): Promise<ShadyElement> {
+async function getReplyElem(
+  trackedParams: string,
+  version: "V1" | "V2",
+): Promise<ShadyElement> {
   return await new Promise((resolve) => {
     const selector =
-      "#replies > ytd-comment-replies-renderer > #expander > #expander-contents > #contents > ytd-comment-renderer";
+      "#replies > ytd-comment-replies-renderer > #expander > #expander-contents > #contents > " +
+      (version === "V1" ? "ytd-comment-renderer" : "ytd-comment-view-model");
 
     const commentRenderer = findElementByTrackingParams<ShadyElement>(
       trackedParams,
-      selector
+      selector,
     );
 
     if (commentRenderer !== null) {
@@ -85,7 +121,7 @@ async function getReplyElem(trackedParams: string): Promise<ShadyElement> {
  * どっちも書き換えとく
  */
 export function rewriteTeaserReplytNameFromContinuationItems(
-  continuationItems: ReplyContinuationItems
+  continuationItems: ReplyContinuationItems,
 ): void {
   debugLog("Teaser Reply Rewrite");
 
@@ -95,7 +131,7 @@ export function rewriteTeaserReplytNameFromContinuationItems(
     if (commentRenderer !== undefined) {
       void reSearchElementAllByCommentId(
         commentRenderer.commentId,
-        "ytd-comment-replies-renderer > #teaser-replies > ytd-comment-renderer"
+        "ytd-comment-replies-renderer > #teaser-replies > ytd-comment-renderer",
       ).then((replyElems) => {
         replyElems.forEach((replyElem) => {
           reWriteReplyElem(replyElem, commentRenderer);
@@ -104,7 +140,7 @@ export function rewriteTeaserReplytNameFromContinuationItems(
 
       void reSearchElementAllByCommentId(
         commentRenderer.commentId,
-        "ytd-comment-replies-renderer > #expander > #expander-contents > #contents > ytd-comment-renderer"
+        "ytd-comment-replies-renderer > #expander > #expander-contents > #contents > ytd-comment-renderer",
       ).then((replyElems) => {
         replyElems.forEach((replyElem) => {
           reWriteReplyElem(replyElem, commentRenderer);
@@ -119,7 +155,7 @@ export function rewriteTeaserReplytNameFromContinuationItems(
  */
 export function replyInputRewrite(replyElem: ShadyElement): void {
   const replyToReplyBtn = replyElem.querySelector(
-    "#reply-button-end > ytd-button-renderer"
+    "#reply-button-end > ytd-button-renderer",
   );
   const replyToReplyHander = (): void => {
     const replyLink = replyElem.querySelector("#contenteditable-root > a");

--- a/src/rewrites/reply.ts
+++ b/src/rewrites/reply.ts
@@ -17,6 +17,7 @@ import { nameRewriteOfCommentRenderer } from "./rewriteOfCommentRenderer/nameRew
 import { debugLog } from "src/utils/debugLog";
 import { getUserName } from "src/utils/getUserName";
 import { nameRewriteOfCommentViewModel } from "./rewriteOfCommentRenderer/nameRewriteOfCommentViewModel";
+import { mentionRewriteOfCommentRendererV2 } from "./rewriteOfCommentRenderer/mentionRewriteOfCommentRendererV2";
 
 /**
  * confinuationItems(コメントをレンダリングする際の元データ？)のリストを元に
@@ -87,6 +88,8 @@ function reWriteReplyElem(
 
 function reWriteReplyElemV2(replyElem: ShadyElement) {
   nameRewriteOfCommentViewModel(replyElem);
+  mentionRewriteOfCommentRendererV2(replyElem);
+  replyInputRewrite(replyElem);
 }
 
 /**

--- a/src/rewrites/rewriteOfCommentRenderer/mentionRewriteOfCommentRendererV2.ts
+++ b/src/rewrites/rewriteOfCommentRenderer/mentionRewriteOfCommentRendererV2.ts
@@ -1,0 +1,39 @@
+import { type ShadyElement } from "../../utils/findElementByTrackingParams";
+import { getUserName } from "../../utils/getUserName";
+import { debugErr } from "src/utils/debugLog";
+import { getShadyChildren } from "src/utils/getShadyChildren";
+
+/**
+ * comment内のaタクを全取得して
+ * 返信先リンクのもののみ書き換え
+ */
+export function mentionRewriteOfCommentRendererV2(
+  commentRenderer: ShadyElement,
+): void {
+  const commentRendererBody = getShadyChildren(commentRenderer, 2, "body");
+  const main = commentRendererBody?.querySelector<ShadyElement>("#main");
+
+  if (main !== undefined && main !== null) {
+    const aTags = main.querySelectorAll(
+      "#expander > #content > #content-text > span > span > a",
+    );
+
+    for (let i = 0; i < aTags.length; i++) {
+      if (aTags[i].textContent?.match("@.*") !== null) {
+        const href = aTags[i].getAttribute("href");
+
+        if (href !== null) {
+          void getUserName(href.split("/")[2])
+            .then((name) => {
+              aTags[i].textContent = `@${name} `;
+            })
+            .catch((e) => {
+              debugErr(e);
+            });
+        } else {
+          debugErr("Mention Atag is have not Href attr");
+        }
+      }
+    }
+  }
+}

--- a/src/rewrites/rewriteOfCommentRenderer/nameRewriteOfCommentViewModel.ts
+++ b/src/rewrites/rewriteOfCommentRenderer/nameRewriteOfCommentViewModel.ts
@@ -1,0 +1,97 @@
+import { debugErr } from "src/utils/debugLog";
+import { escapeString } from "src/utils/escapeString";
+import { ShadyElement } from "src/utils/findElementByTrackingParams";
+import { getShadyChildren } from "src/utils/getShadyChildren";
+import { getUserName } from "src/utils/getUserName";
+
+export function nameRewriteOfCommentViewModel(commentRenderer: ShadyElement) {
+  const commentRendererBody: ShadyElement | null = getShadyChildren(
+    commentRenderer,
+    2,
+    "body",
+  );
+
+  if (commentRendererBody === null) {
+    throw new Error("[rycu] comment renderer body is null");
+  }
+
+  if (!commentRendererBodyGuard(commentRendererBody)) {
+    throw new Error(
+      "[rycu] The object format of comment renderer body is invalid.",
+    );
+  }
+
+  const isNameContainerRender =
+    commentRendererBody.__dataHost.$["author-text"].__dataHost.__data
+      .authorCommentBadge !== null;
+
+  let nameElem = commentRendererBody.querySelector<ShadyElement>(
+    "#main > #header > #header-author > h3 > a > span",
+  );
+
+  const userId =
+    commentRendererBody.__dataHost.$["author-text"].__dataHost.__data
+      .authorEndpoint.browseEndpoint.browseId;
+
+  /**
+   * チャンネル所有者のコメントは別の要素に名前がかかれる
+   */
+  if (isNameContainerRender) {
+    const containerMain = getShadyChildren(commentRendererBody, 1, "main");
+
+    if (containerMain !== null) {
+      nameElem = containerMain.querySelector<ShadyElement>(
+        "#header > #header-author > #author-comment-badge > ytd-author-comment-badge-renderer > a > #channel-name > #container > #text-container > yt-formatted-string",
+      );
+    }
+  }
+
+  /**
+   * 名前要素の書き換え
+   */
+  void getUserName(userId)
+    .then((name) => {
+      if (nameElem !== null) {
+        if (nameElem.getAttribute("is-empty") !== null) {
+          nameElem.removeAttribute("is-empty");
+          //console.log("false");
+        }
+
+        if (isNameContainerRender) {
+          nameElem.__shady_native_innerHTML = escapeString(name);
+        } else {
+          nameElem.textContent = name;
+        }
+      } else {
+        debugErr("Name element is null");
+      }
+    })
+    .catch((e) => {
+      debugErr(e);
+    });
+}
+
+function commentRendererBodyGuard(
+  elem: ShadyElement | CommentRendererBodyElement,
+): elem is CommentRendererBodyElement {
+  return Object.hasOwn(elem, "__dataHost");
+}
+
+type CommentRendererBodyElement = ShadyDataHostElem<{
+  $: {
+    "author-text": ShadyDataHostElem<{
+      __data: {
+        authorCommentBadge: null | { iconTooltip: string };
+        authorEndpoint: {
+          browseEndpoint: {
+            browseId: string;
+          };
+        };
+      };
+    }>;
+  };
+}>;
+
+interface ShadyDataHostElem<T> extends ShadyElement {
+  __dataHost: T;
+}

--- a/src/types/AppendContinuationItemsAction.ts
+++ b/src/types/AppendContinuationItemsAction.ts
@@ -1,10 +1,87 @@
 export type ContinuationItems = Array<{
-  commentThreadRenderer: ConfinuationItem;
+  commentThreadRenderer: ConfinuationItem | ConfinuationItemV2;
+}>;
+
+export type ContinuationItemsV2 = Array<{
+  commentThreadRenderer: ConfinuationItemV2;
 }>;
 
 export type ReplyContinuationItems = Array<{
   commentRenderer: CommentRenderer;
 }>;
+
+export type ReplyContinuationItemsV2 = Array<{
+  commentViewModel: CommentViewModelCommentViewModel;
+}>;
+
+export function isReplyContinuationItemsV1(
+  obj: ReplyContinuationItems | ReplyContinuationItemsV2,
+): obj is ReplyContinuationItems {
+  return Object.hasOwn(obj[0], "commentRenderer");
+}
+
+export function isReplyContinuationItemsV2(
+  obj: ReplyContinuationItems | ReplyContinuationItemsV2,
+): obj is ReplyContinuationItemsV2 {
+  return Object.hasOwn(obj[0], "commentViewModel");
+}
+
+/**
+ * The format of the ConfinuationItem has changed since the version of 02/03/2024
+ */
+export interface ConfinuationItemV2 {
+  trackingParams: string;
+  renderingPriority: string;
+  isModeratedElqComment: boolean;
+  commentViewModel: CommentViewModel;
+  loggingDirectives: LoggingDirectives;
+  replies?: {
+    commentRepliesRenderer: {
+      teaserContents: Array<{
+        commentRenderer: CommentRenderer;
+      }>;
+    };
+  };
+}
+
+export function isConfinuationItemV2(
+  obj: ConfinuationItem | ConfinuationItemV2,
+): obj is ConfinuationItemV2 {
+  return Object.hasOwn(obj, "commentViewModel");
+}
+
+export interface CommentViewModel {
+  commentViewModel: CommentViewModelCommentViewModel;
+}
+
+export interface CommentViewModelCommentViewModel {
+  commentKey: string;
+  sharedKey: string;
+  toolbarStateKey: string;
+  toolbarSurfaceKey: string;
+  commentId: string;
+  commentSurfaceKey: string;
+  rendererContext: RendererContext;
+}
+
+export interface RendererContext {
+  loggingContext: LoggingContext;
+}
+
+export interface LoggingContext {
+  loggingDirectives: LoggingDirectives;
+}
+
+export interface LoggingDirectives {
+  trackingParams: string;
+  visibility: Visibility;
+  enableDisplayloggerExperiment: boolean;
+}
+
+export interface Visibility {
+  types: string;
+}
+/**========================== */
 
 export interface ConfinuationItem {
   comment: Comment;
@@ -19,6 +96,12 @@ export interface ConfinuationItem {
       }>;
     };
   };
+}
+
+export function isConfinuationItemV1(
+  obj: ConfinuationItem | ConfinuationItemV2,
+): obj is ConfinuationItem {
+  return Object.hasOwn(obj, "comment");
 }
 
 export interface Comment {
@@ -43,6 +126,7 @@ export interface CommentRenderer {
   expandButton: Button;
   collapseButton: Button;
   loggingDirectives: LoggingDirectives;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   authorCommentBadge?: any;
 }
 

--- a/src/types/YtAction.ts
+++ b/src/types/YtAction.ts
@@ -11,7 +11,7 @@ export interface YtAction<T, U> {
 }
 
 export interface YtAppendContinuationItemsActionArg0<
-  T extends keyof ContinuationItemsList
+  T extends keyof ContinuationItemsList,
 > {
   appendContinuationItemsAction: {
     continuationItems: ContinuationItemsList[T];

--- a/src/utils/isCommentRenderer.ts
+++ b/src/utils/isCommentRenderer.ts
@@ -1,7 +1,9 @@
 /* eslint-disable no-prototype-builtins */
 import {
+  ReplyContinuationItemsV2,
   type ContinuationItems,
   type ReplyContinuationItems,
+  ContinuationItemsV2,
 } from "src/types/AppendContinuationItemsAction";
 
 /**
@@ -9,7 +11,7 @@ import {
  * @returns trueの場合、リプライ/falseの場合、普通のコメント
  */
 export function isCommentRenderer(
-  continuationItems: ContinuationItems | ReplyContinuationItems
+  continuationItems: ContinuationItems | ReplyContinuationItems,
 ): boolean {
   if (continuationItems.length > 0) {
     if ("commentThreadRenderer" in continuationItems[0]) {
@@ -17,6 +19,22 @@ export function isCommentRenderer(
     }
 
     if ("commentRenderer" in continuationItems[0]) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function isCommentRendererV2(
+  continuationItems: ContinuationItemsV2 | ReplyContinuationItemsV2,
+): boolean {
+  if (continuationItems.length > 0) {
+    if ("commentThreadRenderer" in continuationItems[0]) {
+      return false;
+    }
+
+    if ("commentViewModel" in continuationItems[0]) {
       return true;
     }
   }


### PR DESCRIPTION
`commentRenderer`が`ytd-comment-view-model`に変更された更新により、`ContinuationItems`オブジェクトの構造が変わったため、修正。