### PR TITLE
New Toggle Options & Enhanced Current Live Chat Support

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -19,5 +19,11 @@
   },
   "NameDisplayFormatText": {
     "message": "Name display format"
+  },
+  "ReplaceComments": {
+    "message": "Replace handles in comments"
+  },
+  "ReplaceLiveChats": {
+    "message": "Replace handles in live chats"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -19,5 +19,11 @@
   },
   "NameDisplayFormatText": {
     "message": "名前の表示形式"
+  },
+  "ReplaceComments": {
+    "message": "コメントのユーザー名を置換"
+  },
+  "ReplaceLiveChats": {
+    "message": "ライブチャットのユーザー名を置換"
   }
 }

--- a/popup/index.html
+++ b/popup/index.html
@@ -32,6 +32,18 @@
               <option value="3">Username (@handle)</option>
             </select>
           </li>
+          <li>
+            <label class="toggle-label">
+              <input type="checkbox" id="toggle-comments-replacement" checked />
+              <span class="comments-toggle-text"></span>
+            </label>
+          </li>
+          <li>
+            <label class="toggle-label">
+              <input type="checkbox" id="toggle-live-chats-replacement" checked />
+              <span class="live-chats-toggle-text"></span>
+            </label>
+          </li>
         </ul>
       </div>
     </div>
@@ -115,6 +127,16 @@
       font-size: 14px;
       display: flex;
       gap: 0 10px;
+    }
+
+    .options > li:nth-of-type(n+2) {
+      margin-top: 0.5em;
+    }
+
+    .toggle-label {
+      display: flex;
+      align-items: center;
+      gap: 0 0.5em;
     }
   </style>
 </html>

--- a/popup/main.ts
+++ b/popup/main.ts
@@ -37,6 +37,12 @@ nameDisplayFormatText.innerHTML = chrome.i18n.getMessage(
   "NameDisplayFormatText",
 );
 
+const replaceCommentsText = document.querySelector(".comments-toggle-text")!;
+replaceCommentsText.innerHTML = chrome.i18n.getMessage("ReplaceComments");
+
+const replaceLiveChatsText = document.querySelector(".live-chats-toggle-text")!;
+replaceLiveChatsText.innerHTML = chrome.i18n.getMessage("ReplaceLiveChats");
+
 (async () => {
   // @handle (Name)
   const isShowNameToHandle = await chrome.runtime.sendMessage<
@@ -53,6 +59,22 @@ nameDisplayFormatText.innerHTML = chrome.i18n.getMessage(
     RycuMessageResponseValue<"getShowHandleToName">
   >({
     type: "getShowHandleToName",
+    value: null,
+  });
+
+  const isReplaceComments = await chrome.runtime.sendMessage<
+    RycuMessageRequest,
+    RycuMessageResponseValue<"getReplaceComments">
+  >({
+    type: "getReplaceComments",
+    value: null,
+  });
+
+  const isReplaceLiveChats = await chrome.runtime.sendMessage<
+    RycuMessageRequest,
+    RycuMessageResponseValue<"getReplaceLiveChats">
+  >({
+    type: "getReplaceLiveChats",
     value: null,
   });
 
@@ -95,6 +117,28 @@ nameDisplayFormatText.innerHTML = chrome.i18n.getMessage(
         break;
     }
   });
+
+  const commentsReplacementToggle = document.querySelector<HTMLInputElement>(
+    "#toggle-comments-replacement",
+  )!;
+  commentsReplacementToggle.checked = isReplaceComments;
+  commentsReplacementToggle.addEventListener("change", (e) => {
+    if (!(e.target instanceof HTMLInputElement)) {
+      return;
+    }
+    setReplaceComments(e.target.checked);
+  });
+
+  const liveChatReplacementToggle = document.querySelector<HTMLInputElement>(
+    "#toggle-live-chats-replacement",
+  )!;
+  liveChatReplacementToggle.checked = isReplaceLiveChats;
+  liveChatReplacementToggle.addEventListener("change", (e) => {
+    if (!(e.target instanceof HTMLInputElement)) {
+      return;
+    }
+    setReplaceLiveChats(e.target.checked);
+  });
 })();
 
 // @handle (Name)
@@ -115,6 +159,26 @@ async function setShowHandleToName(is: boolean) {
     RycuMessageResponseValue<"setShowHandleToName">
   >({
     type: "setShowHandleToName",
+    value: is,
+  });
+}
+
+async function setReplaceComments(is: boolean) {
+  await chrome.runtime.sendMessage<
+    RycuMessageRequest,
+    RycuMessageResponseValue<"setReplaceComments">
+  >({
+    type: "setReplaceComments",
+    value: is,
+  });
+}
+
+async function setReplaceLiveChats(is: boolean) {
+  await chrome.runtime.sendMessage<
+    RycuMessageRequest,
+    RycuMessageResponseValue<"setReplaceLiveChats">
+  >({
+    type: "setReplaceLiveChats",
     value: is,
   });
 }

--- a/src/rewrites/comment.ts
+++ b/src/rewrites/comment.ts
@@ -17,13 +17,19 @@ import {
   isCommentViewModelElement,
   nameRewriteOfCommentViewModel,
 } from "./rewriteOfCommentRenderer/nameRewriteOfCommentViewModel";
+import { type RycuSettings } from "src/types/RycuSettings";
 
 /**
  * confinuationItemsを元にコメントの名前を書き換える。
  */
 export function rewriteCommentNameFromContinuationItems(
   continuationItems: ContinuationItems,
+  settings: RycuSettings = window.__rycu.settings,
 ): void {
+  if (!settings.isReplaceComments) {
+    return;
+  }
+
   debugLog("Rewrite Comment.");
 
   for (let i = 0; i < continuationItems.length; i++) {

--- a/src/rewrites/rewriteOfCommentRenderer/nameRewriteOfCommentViewModel.ts
+++ b/src/rewrites/rewriteOfCommentRenderer/nameRewriteOfCommentViewModel.ts
@@ -2,6 +2,8 @@ import { debugErr } from "src/utils/debugLog";
 import { escapeString } from "src/utils/escapeString";
 import { ShadyElement } from "src/utils/findElementByTrackingParams";
 import { getUserName } from "src/utils/getUserName";
+import { formatUserName } from "src/utils/formatUserName";
+import { type RycuSettings } from "src/types/RycuSettings";
 
 export type CommentViewModelElement = ShadyElement<{
   authorChannelName: string;
@@ -37,6 +39,7 @@ export function isCommentViewModelElement(
 
 export function nameRewriteOfCommentViewModel(
   commentViewModel: CommentViewModelElement,
+  settings: RycuSettings = window.__rycu.settings,
 ) {
   const commentViewModelBody: ShadyElement | null =
     commentViewModel.__shady_native_children.namedItem("body");
@@ -83,13 +86,7 @@ export function nameRewriteOfCommentViewModel(
           //console.log("false");
         }
 
-        let innerText = name;
-        if (window.__rycu.settings.isShowNameToHandle) {
-          innerText = decodeURI(userHandle) + `  ( ${name} )`;
-        }
-        if (window.__rycu.settings.isShowHandleToName) {
-          innerText = name + `  ( ${decodeURI(userHandle)} )`;
-        }
+        const innerText = formatUserName(name, userHandle, settings);
 
         if (isNameContainerRender) {
           nameElem.textContent = escapeString(innerText);

--- a/src/types/RycuSettings.ts
+++ b/src/types/RycuSettings.ts
@@ -1,0 +1,13 @@
+export interface RycuSettings {
+  isShowHandleToName: boolean;
+  isShowNameToHandle: boolean;
+  isReplaceComments: boolean;
+  isReplaceLiveChats: boolean;
+}
+
+export const getDefaultSettings = (): RycuSettings => ({
+  isShowHandleToName: false,
+  isShowNameToHandle: false,
+  isReplaceComments: true,
+  isReplaceLiveChats: true,
+});

--- a/src/types/Storage.ts
+++ b/src/types/Storage.ts
@@ -1,0 +1,13 @@
+export interface RycuStorage {
+  showHandleToName: boolean;
+  showNameToHandle: boolean;
+  replaceComments: boolean;
+  replaceLiveChats: boolean;
+}
+
+export const getDefaultStorageCache = (): RycuStorage => ({
+  showHandleToName: false,
+  showNameToHandle: false,
+  replaceComments: true,
+  replaceLiveChats: true,
+});

--- a/src/types/SyncSettings.ts
+++ b/src/types/SyncSettings.ts
@@ -1,0 +1,61 @@
+import { bypassSendMessage, getRunningRuntime } from "crx-monkey";
+import { RycuMessageRequest, RycuMessageResponseValue } from "sw/sw";
+import { type RycuSettings } from "src/types/RycuSettings";
+
+export const syncSettings = (settings: RycuSettings) => {
+  bypassSendMessage<
+    RycuMessageRequest,
+    RycuMessageResponseValue<"getShowHandleToName">
+  >(
+    {
+      type: "getShowHandleToName",
+      value: null,
+    },
+    {},
+    (isShowHandleToName) => {
+      settings.isShowHandleToName = isShowHandleToName;
+    },
+  );
+
+  bypassSendMessage<
+    RycuMessageRequest,
+    RycuMessageResponseValue<"getShowNameToHandle">
+  >(
+    {
+      type: "getShowNameToHandle",
+      value: null,
+    },
+    {},
+    (isShowNameToHandle) => {
+      settings.isShowNameToHandle = isShowNameToHandle;
+    },
+  );
+
+  bypassSendMessage<
+    RycuMessageRequest,
+    RycuMessageResponseValue<"getReplaceComments">
+  >(
+    {
+      type: "getReplaceComments",
+      value: null,
+    },
+    {},
+    (isReplaceComments) => {
+      settings.isReplaceComments = isReplaceComments;
+    },
+  );
+
+  bypassSendMessage<
+    RycuMessageRequest,
+    RycuMessageResponseValue<"getReplaceLiveChats">
+  >(
+    {
+      type: "getReplaceLiveChats",
+      value: null,
+    },
+    {},
+    (isReplaceLiveChats) => {
+      settings.isReplaceLiveChats = isReplaceLiveChats;
+    },
+  );
+};

--- a/src/utils/formatUserName.ts
+++ b/src/utils/formatUserName.ts
@@ -1,0 +1,17 @@
+import type { RycuSettings } from "src/index";
+
+export function formatUserName(
+  userName: string,
+  userHandle: string,
+  settings: RycuSettings,
+): string {
+  if (settings.isShowNameToHandle) {
+    return decodeURI(userHandle) + `  ( ${userName} )`;
+  }
+
+  if (settings.isShowHandleToName) {
+    return userName + `  ( ${decodeURI(userHandle)} )`;
+  }
+
+  return userName;
+}

--- a/src/utils/getSettings.ts
+++ b/src/utils/getSettings.ts
@@ -1,0 +1,23 @@
+import { type RycuSettings, getDefaultSettings } from "src/types/RycuSettings";
+import { type RycuStorage, getDefaultStorageCache } from "src/types/Storage";
+
+export function getSettings(): Promise<RycuSettings> {
+  const defaultStorageCache: RycuStorage = getDefaultStorageCache();
+  const defaultSettings: RycuSettings = getDefaultSettings();
+
+  return chrome.storage.local
+    .get({
+      showHandleToName: defaultSettings.isShowHandleToName,
+      showNameToHandle: defaultSettings.isShowNameToHandle,
+      replaceComments: defaultSettings.isReplaceComments,
+      replaceLiveChats: defaultSettings.isReplaceLiveChats,
+    })
+    .then((items) => {
+      return {
+        isShowHandleToName: items.showHandleToName,
+        isShowNameToHandle: items.showNameToHandle,
+        isReplaceComments: items.replaceComments,
+        isReplaceLiveChats: items.replaceLiveChats,
+      };
+    });
+}

--- a/sw/sw.ts
+++ b/sw/sw.ts
@@ -1,8 +1,9 @@
 import { setupInstallPage } from "./setupInstallPage";
+import { type RycuStorage, getDefaultStorageCache } from "src/types/Storage";
 
 setupInstallPage();
 
-const storageCache = { showHandleToName: false, showNameToHandle: false };
+const storageCache: RycuStorage = getDefaultStorageCache();
 const initStorageCache = chrome.storage.local.get().then((items) => {
   Object.assign(storageCache, items);
 });
@@ -29,6 +30,14 @@ chrome.runtime.onMessage.addListener(
       send(storageCache.showNameToHandle);
     }
 
+    if (req.type === "getReplaceComments") {
+      send(storageCache.replaceComments);
+    }
+
+    if (req.type === "getReplaceLiveChats") {
+      send(storageCache.replaceLiveChats);
+    }
+
     if (req.type === "setShowHandleToName") {
       chrome.storage.local
         .set({ showHandleToName: req.value })
@@ -46,6 +55,24 @@ chrome.runtime.onMessage.addListener(
           Object.assign(storageCache, { showNameToHandle: req.value });
         });
     }
+
+    if (req.type === "setReplaceComments") {
+      chrome.storage.local
+        .set({ replaceComments: req.value })
+        .then(async () => {
+          await initStorageCache;
+          Object.assign(storageCache, { replaceComments: req.value });
+        });
+    }
+
+    if (req.type === "setReplaceLiveChats") {
+      chrome.storage.local
+        .set({ replaceLiveChats: req.value })
+        .then(async () => {
+          await initStorageCache;
+          Object.assign(storageCache, { replaceLiveChats: req.value });
+        });
+    }
   },
 );
 
@@ -61,15 +88,23 @@ interface RycuMessageRequestValues {
   err: string[];
   setShowHandleToName: boolean;
   setShowNameToHandle: boolean;
+  setReplaceComments: boolean;
+  setReplaceLiveChats: boolean;
   getShowHandleToName: null;
   getShowNameToHandle: null;
+  getReplaceComments: null;
+  getReplaceLiveChats: null;
 }
 
 interface RycuMessageResponseValues {
   setShowHandleToName: boolean;
   setShowNameToHandle: boolean;
+  setReplaceComments: boolean;
+  setReplaceLiveChats: boolean;
   getShowHandleToName: boolean;
   getShowNameToHandle: boolean;
+  getReplaceComments: boolean;
+  getReplaceLiveChats: boolean;
 }
 
 export type RycuMessageResponseValue<


### PR DESCRIPTION
## Summary

This PR extends the name display format options to Live Chat and adds granular toggle controls for comment/live chat replacement.

## Changelog

### Features

- **Name display format now applies to Live Chat**
  - The existing "Name display format" option (Name only / @handle (Name) / Name (@handle)) now works in Live Chat messages, not just comments.

- **New toggle options added**
  - "Replace handles in comments" - Enable/disable handle replacement in video comments
  - "Replace handles in live chats" - Enable/disable handle replacement in live chat messages

### Improvements

- **Instant apply without page refresh**
  - All three options take effect immediately on **new** comments/chat messages after toggling, no page reload required.
  - **Note:** Other YouTube tabs (not the one where you changed the options via popup) may require a page/chat-iframe refresh, as settings are not fetched from `chrome.storage` on every time. (getSettings)

## Technical Changes

### New Files
- `src/types/RycuSettings.ts` - Centralized settings type definition and defaults
- `src/types/SyncSettings.ts` - Extracted `syncSettings()` for reuse across scripts
- `src/types/Storage.ts` - Storage type definition and defaults
- `src/utils/formatUserName.ts` - Extracted username formatting logic for reuse

### Modified Files
- `src/index.ts` - Refactored to use new shared modules
- `src/liveChat.ts` - Now uses `parent.window.__rycu.settings` to share state with main page, added `formatUserName` support
- `src/rewrites/comment.ts` - Added `isReplaceComments` check
- `src/rewrites/rewriteOfCommentRenderer/nameRewriteOfCommentViewModel.ts` - Refactored to use `formatUserName()`
- `sw/sw.ts` - Added `replaceComments` and `replaceLiveChats` to storage cache and message handlers
- `popup/index.html` - Added toggle checkboxes UI
- `popup/main.ts` - Added toggle event handlers
- `_locales/en/messages.json` - Added i18n strings
- `_locales/ja/messages.json` - Added i18n strings

### Key Implementation Detail
Live Chat iframe accesses settings via `parent.window.__rycu.settings` to share state with the main page, avoiding duplicate storage sync.

<img width="360" src="https://github.com/user-attachments/assets/6cad6f5c-63c6-4362-8ab6-9e8b1b55969c" />
<img width="360" src="https://github.com/user-attachments/assets/0e92bf44-abf6-4680-94e1-0edfdca943fa" />
<br>
<img width="360" src="https://github.com/user-attachments/assets/9c7df3fb-50ae-4b63-9376-33884692cf11" />
<img width="360" src="https://github.com/user-attachments/assets/4c91bb5a-357a-41f5-8cf7-7e9075e393aa" />